### PR TITLE
fix text span component should be under p

### DIFF
--- a/apps/react/src/assets/flex/usa_national_park.json
+++ b/apps/react/src/assets/flex/usa_national_park.json
@@ -1,0 +1,245 @@
+{
+  "type": "bubble",
+  "size": "giga",
+  "body": {
+    "type": "box",
+    "layout": "vertical",
+    "contents": [
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [
+          {
+            "type": "box",
+            "layout": "vertical",
+            "contents": [
+              {
+                "type": "text",
+                "text": "USA National Parks",
+                "color": "#ffffff",
+                "weight": "bold",
+                "align": "center",
+                "size": "xl",
+                "maxLines": 1
+              }
+            ],
+            "paddingBottom": "25px",
+            "paddingTop": "25px"
+          }
+        ],
+        "backgroundColor": "#222222",
+        "paddingStart": "10px",
+        "paddingEnd": "10px"
+      },
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [
+          {
+            "type": "box",
+            "layout": "horizontal",
+            "contents": [
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit",
+                        "url": "https://images.unsplash.com/photo-1604542031658-5799ca5d7936?q=80"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2538?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Yosemite National Park",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "California",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "url": "https://images.unsplash.com/photo-1615551043360-33de8b5f410c?q=80",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2535?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Grand Canyon",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "Arizona",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "url": "https://images.unsplash.com/photo-1606516397986-1eeb79e8c052?q=80",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2533?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Niagara Falls",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "New York",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              }
+            ],
+            "paddingTop": "10px",
+            "paddingBottom": "20px"
+          }
+        ],
+        "paddingTop": "5px",
+        "backgroundColor": "#ffffff"
+      },
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [],
+        "backgroundColor": "#07B53B"
+      }
+    ],
+    "paddingAll": "0px"
+  }
+}

--- a/apps/react/src/assets/flex/usa_national_park.json
+++ b/apps/react/src/assets/flex/usa_national_park.json
@@ -59,12 +59,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2538?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",
@@ -120,12 +115,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2535?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",
@@ -181,12 +171,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2533?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",

--- a/apps/react/src/assets/samples.json
+++ b/apps/react/src/assets/samples.json
@@ -346,5 +346,11 @@
     "title": "Kerry Tracking",
     "author": "Supakarn Laorattanakul",
     "authorUrl": "https://www.facebook.com/wearedprompt"
+  },
+  {
+    "id": "usa_national_park",
+    "title": "USA National Park",
+    "author": "Traitanit Huangsri",
+    "authorUrl": "https://www.facebook.com/nottyo"
   }
 ]

--- a/apps/vue/.yarnrc
+++ b/apps/vue/.yarnrc
@@ -1,1 +1,0 @@
-"@linecorp:registry" "https://npm.linecorp.com"

--- a/apps/vue/.yarnrc
+++ b/apps/vue/.yarnrc
@@ -1,0 +1,1 @@
+"@linecorp:registry" "https://npm.linecorp.com"

--- a/apps/vue/src/assets/flex/usa_national_park.json
+++ b/apps/vue/src/assets/flex/usa_national_park.json
@@ -1,0 +1,245 @@
+{
+  "type": "bubble",
+  "size": "giga",
+  "body": {
+    "type": "box",
+    "layout": "vertical",
+    "contents": [
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [
+          {
+            "type": "box",
+            "layout": "vertical",
+            "contents": [
+              {
+                "type": "text",
+                "text": "USA National Parks",
+                "color": "#ffffff",
+                "weight": "bold",
+                "align": "center",
+                "size": "xl",
+                "maxLines": 1
+              }
+            ],
+            "paddingBottom": "25px",
+            "paddingTop": "25px"
+          }
+        ],
+        "backgroundColor": "#222222",
+        "paddingStart": "10px",
+        "paddingEnd": "10px"
+      },
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [
+          {
+            "type": "box",
+            "layout": "horizontal",
+            "contents": [
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit",
+                        "url": "https://images.unsplash.com/photo-1604542031658-5799ca5d7936?q=80"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2538?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Yosemite National Park",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "California",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "url": "https://images.unsplash.com/photo-1615551043360-33de8b5f410c?q=80",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2535?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Grand Canyon",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "Arizona",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              },
+              {
+                "type": "box",
+                "layout": "vertical",
+                "contents": [
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "image",
+                        "url": "https://images.unsplash.com/photo-1606516397986-1eeb79e8c052?q=80",
+                        "size": "full",
+                        "aspectRatio": "1:1",
+                        "aspectMode": "fit"
+                      }
+                    ],
+                    "height": "100px",
+                    "cornerRadius": "5px",
+                    "action": {
+                      "type": "uri",
+                      "label": "compactMelody",
+                      "uri": "https://liff.line-beta.me/compact/melody/2533?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
+                    }
+                  },
+                  {
+                    "type": "box",
+                    "layout": "vertical",
+                    "contents": [
+                      {
+                        "type": "text",
+                        "color": "#353535",
+                        "weight": "bold",
+                        "size": "md",
+                        "wrap": false,
+                        "align": "center",
+                        "contents": [
+                          {
+                            "type": "span",
+                            "text": "Niagara Falls",
+                            "size": "sm"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "text",
+                        "text": "New York",
+                        "size": "xs",
+                        "wrap": false,
+                        "color": "#353535",
+                        "align": "center"
+                      }
+                    ],
+                    "width": "100px"
+                  }
+                ],
+                "width": "100px",
+                "spacing": "sm"
+              },
+              {
+                "type": "filler"
+              }
+            ],
+            "paddingTop": "10px",
+            "paddingBottom": "20px"
+          }
+        ],
+        "paddingTop": "5px",
+        "backgroundColor": "#ffffff"
+      },
+      {
+        "type": "box",
+        "layout": "vertical",
+        "contents": [],
+        "backgroundColor": "#07B53B"
+      }
+    ],
+    "paddingAll": "0px"
+  }
+}

--- a/apps/vue/src/assets/flex/usa_national_park.json
+++ b/apps/vue/src/assets/flex/usa_national_park.json
@@ -59,12 +59,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2538?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",
@@ -120,12 +115,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2535?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",
@@ -181,12 +171,7 @@
                       }
                     ],
                     "height": "100px",
-                    "cornerRadius": "5px",
-                    "action": {
-                      "type": "uri",
-                      "label": "compactMelody",
-                      "uri": "https://liff.line-beta.me/compact/melody/2533?utm_source=line&utm_medium=share_FMS&utm_campaign=showcase"
-                    }
+                    "cornerRadius": "5px"
                   },
                   {
                     "type": "box",

--- a/apps/vue/src/assets/samples.json
+++ b/apps/vue/src/assets/samples.json
@@ -346,5 +346,11 @@
     "title": "Kerry Tracking",
     "author": "Supakarn Laorattanakul",
     "authorUrl": "https://www.facebook.com/wearedprompt"
+  },
+  {
+    "id": "usa_national_park",
+    "title": "USA National Park",
+    "author": "Traitanit Huangsri",
+    "authorUrl": "https://www.facebook.com/nottyo"
   }
 ]

--- a/packages/flex-render/src/utils/render.ts
+++ b/packages/flex-render/src/utils/render.ts
@@ -304,12 +304,13 @@ export const renderIcon = (iconJSON: FlexIcon, parent?: FlexComponent) => {
 export const renderText = (textJSON: FlexText, parent?: FlexComponent) => {
   let text = new Element('div')
   text.addClassNames(FlexElementClassName.text)
-
   if (textJSON.contents && textJSON.contents.length > 0) {
     for (const contentJSON of textJSON.contents) {
       const content = renderContent(contentJSON, textJSON)
       if (!content) continue
-      text.appendChild(content)
+      const textContent = new Element('p')
+      textContent.appendChild(content)
+      text.appendChild(textContent)
     }
   } else if (textJSON.text) {
     const textContent = new Element('p')
@@ -351,7 +352,6 @@ export const renderSpan = (spanJSON: FlexSpan, parent?: FlexComponent) => {
   span = injectWeight(span, spanJSON.weight)
   span = injectFontStyle(span, spanJSON.style)
   span = injectFontDecoration(span, spanJSON.decoration)
-
   return span
 }
 


### PR DESCRIPTION
Hello @iamprompt,
I found an issue while rendering flex-message with span under text component.

The `span` in text component should be render under `<p>` to be the same as we seeing in flex-simulator.
And another issue is the text `wrap` property does not work properly when setting the value as `false`. So adding `<span>` under `<p>` also fix this issue.

Before:
![image](https://github.com/iamprompt/flex-render/assets/8110002/439248b9-b615-4a51-9a4b-6d7c97b4a5fd)

After:
![image](https://github.com/iamprompt/flex-render/assets/8110002/6c6ef680-a342-414d-bb23-286efa12ac85)

Please review