### PR TITLE
add box action handler

### DIFF
--- a/apps/react/src/assets/flex/usa_national_park.json
+++ b/apps/react/src/assets/flex/usa_national_park.json
@@ -93,7 +93,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "uri",
+                  "label": "yosemite",
+                  "uri": "https://www.nps.gov/yose/index.htm"
+                }
               },
               {
                 "type": "filler"
@@ -149,7 +154,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "message",
+                  "label": "action",
+                  "text": "hello from grand-canyon"
+                }
               },
               {
                 "type": "filler"
@@ -205,7 +215,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "postback",
+                  "label": "niagara-postback",
+                  "data": "hello from niagara-postback"
+                }
               },
               {
                 "type": "filler"

--- a/apps/vue/src/assets/flex/usa_national_park.json
+++ b/apps/vue/src/assets/flex/usa_national_park.json
@@ -93,7 +93,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "uri",
+                  "label": "yosemite",
+                  "uri": "https://www.nps.gov/yose/index.htm"
+                }
               },
               {
                 "type": "filler"
@@ -149,7 +154,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "message",
+                  "label": "action",
+                  "text": "hello from grand-canyon"
+                }
               },
               {
                 "type": "filler"
@@ -205,7 +215,12 @@
                   }
                 ],
                 "width": "100px",
-                "spacing": "sm"
+                "spacing": "sm",
+                "action": {
+                  "type": "postback",
+                  "label": "niagara-postback",
+                  "data": "hello from niagara-postback"
+                }
               },
               {
                 "type": "filler"

--- a/packages/flex-render/src/utils/render.ts
+++ b/packages/flex-render/src/utils/render.ts
@@ -155,7 +155,6 @@ export const renderHero = (heroJSON: FlexBox | FlexImage | FlexVideo) => {
 
 export const renderBox = (boxJSON: FlexBox, parent?: FlexComponent) => {
   let box = new Element('div')
-
   if (boxJSON.contents) {
     for (const contentJSON of boxJSON.contents) {
       const content = renderContent(contentJSON, boxJSON)
@@ -183,7 +182,9 @@ export const renderBox = (boxJSON: FlexBox, parent?: FlexComponent) => {
   box = injectOffset(box, boxJSON)
   box = injectPadding(box, boxJSON)
   box = injectBackground(box, boxJSON.background)
-
+  if (boxJSON.action) {
+    box = injectAction(box, boxJSON.action)
+  }
   return box
 }
 

--- a/packages/flex-render/src/utils/utils.ts
+++ b/packages/flex-render/src/utils/utils.ts
@@ -455,6 +455,7 @@ export const injectAction = <T extends Element>(element: T, action?: Action) => 
     case 'uri':
       element.setAttribute('target', '_blank')
       element.setAttribute('href', (action as URIAction).uri || '')
+      element.setAttribute('onclick', `window.open('${(action as URIAction).uri || ''}')`)
       break
     case 'message':
       element.setAttribute('onclick', `alert('Send Message: ${(action as MessageAction).text} to chatroom')`)


### PR DESCRIPTION
Hello @iamprompt,

I'd like to add the box component action handler for example add the `onclick` attribute to `div` (to make it clickable) when flexbox contains `uri` action. So that we can simulate the real use case when users do some action on a box component.

I also updated my example flex message JSON `usa_national_park.json` to provide some example when clicking on each box item.

Please review.

![box-action-handler](https://github.com/iamprompt/flex-render/assets/8110002/4f524916-f5bd-4097-bd19-9e7819a01d50)
